### PR TITLE
Minimal async support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ flume = "0.11.0"
 
 [dev-dependencies]
 clap = { version = "4.4.8", features = ["derive"] }
+
+[features]
+async = []
+default = ["async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_bytes = "0.11.5"
 thiserror = "1.0.49"
 crc = "3.0.1"
 sha1_smol = "1.0.0"
+flume = "0.11.0"
 
 [dev-dependencies]
 clap = { version = "4.4.8", features = ["derive"] }

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -1,7 +1,5 @@
-use std::{
-    net::SocketAddr,
-    sync::mpsc::{Receiver, Sender},
-};
+use flume::{Receiver, Sender};
+use std::net::SocketAddr;
 
 use super::{Id, Node};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,5 +34,5 @@ pub enum Error {
 
     #[error(transparent)]
     /// Transparent [std::io::Error]
-    Receive(#[from] std::sync::mpsc::RecvError),
+    Receive(#[from] flume::RecvError),
 }


### PR DESCRIPTION
Use flume channels instead of std::mpsc channel to have the option to do async.

Expose a minimal async API under a feature flag, so you can avoid needless spawn_blocking to e.g. wait for a result.